### PR TITLE
Fixes command name in activationCommands list

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Run phpcbf on the current file.",
   "keywords": [],
   "activationCommands": {
-    "atom-workspace": "phpcbf:run"
+    "atom-workspace": "phpcbf:fix"
   },
   "repository": "https://github.com/jcartledge/atom-phpcbf",
   "license": "MIT",


### PR DESCRIPTION
When I initially downloaded this plugin I couldn't seem to get it to work when using the command pallet.

Changing the command from 'run' to 'fix' to match the main file fixed this
