### PR TITLE
Simplifies the command titles in the context menus

### DIFF
--- a/menus/phpcbf.cson
+++ b/menus/phpcbf.cson
@@ -1,7 +1,7 @@
 'context-menu':
   'atom-text-editor': [
     {
-      'label': 'Run phpcbf on current file'
+      'label': 'PHPCBF: Reformat'
       'command': 'phpcbf:fix'
     }
   ]
@@ -9,10 +9,10 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'phpcbf'
+      'label': 'PHPCBF'
       'submenu': [
         {
-          'label': 'Fix current file'
+          'label': 'Reformat'
           'command': 'phpcbf:fix'
         }
       ]


### PR DESCRIPTION
I believe that because the menu is contextual it's not necessary to explain what the fixer is running against. I'm still not 100% on the wording but do you think this is more suitable?

![image](https://cloud.githubusercontent.com/assets/846587/10849365/61fed2c6-7f18-11e5-9cb4-b4092cce93fc.png)
