### PR TITLE
Ensure only php files are reformatted

### DIFF
--- a/lib/phpcbf.coffee
+++ b/lib/phpcbf.coffee
@@ -27,13 +27,17 @@ module.exports = Phpcbf =
     @subscriptions.add atom.config.observe 'phpcbf.standard',
       (standard) => @standard = standard
 
-    # @TODO: scope to PHP files.
     @subscriptions.add atom.commands.add 'atom-workspace', 'phpcbf:fix': => @fix()
 
   deactivate: ->
     @subscriptions.dispose()
 
   fix: ->
+    editor = atom.workspace.getActiveTextEditor();
+    if (editor.getGrammar().name != "PHP")
+        atom.notifications.addWarning("Can't reformat #{editor.getGrammar().name} files");
+        return;
+
     which @executablePath, (err, phpcbf) =>
       # @TODO: handle error properly: display to the user.
       if err


### PR DESCRIPTION
Check the scope of the editor and if it isn't php show a warning to the user. Eg when running against a css file

![image](https://cloud.githubusercontent.com/assets/846587/10849812/61624a62-7f1a-11e5-9e3f-b301fb985af6.png)
